### PR TITLE
Clarify focus on technical metadata in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ For __questions relating to this repository__ and the use of its metadata templa
 
 This repository is maintained by [SciLifeLab Data Centre](https://www.scilifelab.se/data/) and [NBIS](https://nbis.se/). The data-type specific metadata templates are created in collaboration with SciLifeLab data producing platforms. For contributors to individual metadata templates please see the relevant subsection on the specific template readme pages. 
 
-This work was originally started in the context of a NBIS Technical Development Project in collaboration between NGI, NBIS and SciLifeLab Data Centre. 
+This work was originally started in the context of a NBIS Technical Development Project in collaboration between [NGI](https://ngisweden.scilifelab.se/), NBIS and SciLifeLab Data Centre. 


### PR DESCRIPTION
Updated the README to clarify focus on technical metadata and add sentence on origin of project. 