### PR TITLE
Fix: update correct genomics readme with table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 *.pyc
 *.pyo
 *.pyd
+
+*.egg-info/
+
 .venv/

--- a/src/scilifelab_metadata_templates/genomics/generate_genomics_template.py
+++ b/src/scilifelab_metadata_templates/genomics/generate_genomics_template.py
@@ -80,8 +80,12 @@ if __name__ == "__main__":
         f"JSON schema generated and saved to {', '.join([str(x.with_name(x.name+ '_schema.json')) for x in output_paths])}"
     )
 
-    # update readme
-    readme_file_path = base_dir / "README.md"
-    table_start = "<!-- START OF OVERVIEW TABLE -->"
-    table_end = "<!-- END OF OVERVIEW TABLE -->"
-    update_markdown_table(readme_file_path, table_start, table_end, all_fields)
+    # update genomics readme
+    if repo_root:
+        readme_file_path = repo_root / base_dir.name / "README.md"
+        table_start = "<!-- START OF OVERVIEW TABLE -->"
+        table_end = "<!-- END OF OVERVIEW TABLE -->"
+        update_markdown_table(readme_file_path, table_start, table_end, all_fields)
+        print(f"README.md updated with overview table at {readme_file_path}")
+    else:
+        print("genomics/README.md not updated because the repository root could not be found.")


### PR DESCRIPTION
This PR updates the genomics template creation to update the correct readme with the table listing all metadata fields and CVs. It should be displayed in the genomics-centered readme under `genomics/README.md` and not the one explaining the scripts under `src/scilifelab_metadata_templates/genomics/`. 

It also adds the .egg-info folder to the `.gitignore` file to avoid adding it to the repository when the GitHub Action rebuilds the template. 